### PR TITLE
6-to-be-able-to-assert-if-a-page-has-passed-certain-or-all-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New methods `Lightship::allRulesPassed()`, `Lightship::rulePassed()` and `Lightship::someRulesPassed()` ([#6](https://github.com/lightship-core/lightship-php/issues/6)).
+
 ## [0.7.1] 2022-05-05
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Since my web app is fully server-side, all my tests are very fast, and do not re
 - [1. Simple example code-driver](#1-simple-example-code-driven)
 - [2. Simple example using a configuration file](#2-simple-example-using-a-configuration-file)
 - [3. Set a response callback](#3-set-a-response-callback)
+- [4. Assert rule passed for URLs](#4-assert-rule-passed-for-urls)
 
 ### 1. Simple example code-driven
 
@@ -160,6 +161,28 @@ This will display something like this:
 ```bash
 https://example.com/: 38
 https://northerwind.com/: 61
+```
+
+### 4. Assert rule passed for URLs
+
+Useful in your tests and CI, you can assert your URLs pass some/all rules.
+
+```php
+use Lightship\Lightship;
+use Lightship\Rules\Seo\LangPresent;
+use Lightship\Rules\Performance\FastResponseTime;
+
+$lightship = new Lightship();
+
+$lightship->route("https://example.com")
+  ->route("https://google.com")
+  ->analyse();
+
+assert($lightship->rulePassed(["https://example.com"], LangPresent::class) === true);
+
+assert($lightship->allRulesPassed(["https://google.com"]) === true);
+
+assert($lightship->someRulesPassed(["https://google.com"], [LangPresent::class, FastResponseTime::class]) === true);
 ```
 
 ## Tests

--- a/src/Exceptions/RuleNotFoundException.php
+++ b/src/Exceptions/RuleNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lightship\Exceptions;
+
+use Exception;
+
+class RuleNotFoundException extends Exception
+{
+}

--- a/src/Exceptions/UrlNotFoundException.php
+++ b/src/Exceptions/UrlNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lightship\Exceptions;
+
+use Exception;
+
+class UrlNotFoundException extends Exception
+{
+}

--- a/src/Report.php
+++ b/src/Report.php
@@ -54,7 +54,7 @@ class Report
     public function results(RuleType $ruleType): array
     {
         return array_map(
-            fn (RuleReport $report): Result => new Result($report->name(), $report->passes()),
+            fn (RuleReport $report): Result => new Result($report->name(), $report->passes(), $ruleType),
             array_values(
                 array_filter(
                     $this->ruleReports,
@@ -62,6 +62,40 @@ class Report
                 )
             )
         );
+    }
+
+    public function ruleTypePassed(RuleType $ruleType): bool
+    {
+        return count(array_filter($this->results($ruleType), fn (Result $result): bool => !$result->passes)) === 0;
+    }
+
+    public function allRulesPassed(): bool
+    {
+        return $this->ruleTypePassed(RuleType::Accessibility) ||
+            $this->ruleTypePassed(RuleType::Performance) ||
+            $this->ruleTypePassed(RuleType::Security) ||
+            $this->ruleTypePassed(RuleType::Seo);
+    }
+
+    public function rulePassed(Rule $rule): bool
+    {
+        /**
+         * @var array<Result>
+         */
+        $results = array_values(
+            array_filter(
+                $this->results($rule->type()),
+                fn (Result $result): bool => $result->name === $rule->name()
+            )
+        );
+
+        if (count($results) === 0) {
+            return false;
+        }
+
+        $result = $results[0];
+
+        return $result->passes;
     }
 
     /**

--- a/src/Result.php
+++ b/src/Result.php
@@ -11,7 +11,8 @@ class Result
 {
     public function __construct(
         public readonly string $name,
-        public readonly bool $passes
+        public readonly bool $passes,
+        public readonly RuleType $ruleType,
     ) {
     }
 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -11,4 +11,6 @@ interface Rule
     public function toReport(): RuleReport;
 
     public function type(): RuleType;
+
+    public function name(): string;
 }

--- a/src/Rules/Accessibility/ButtonsAndLinksUseAccessibleName.php
+++ b/src/Rules/Accessibility/ButtonsAndLinksUseAccessibleName.php
@@ -13,9 +13,13 @@ class ButtonsAndLinksUseAccessibleName extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "buttonsAndLinksUseAccessibleName";
         $this->value = 15;
         $this->type = RuleType::Accessibility;
+    }
+
+    public function name(): string
+    {
+        return "buttonsAndLinksUseAccessibleName";
     }
 
     protected function passes(): bool

--- a/src/Rules/Accessibility/DoctypeHtmlPresent.php
+++ b/src/Rules/Accessibility/DoctypeHtmlPresent.php
@@ -9,9 +9,13 @@ class DoctypeHtmlPresent extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "doctypeHtmlPresent";
         $this->value = 14;
         $this->type = RuleType::Accessibility;
+    }
+
+    public function name(): string
+    {
+        return "doctypeHtmlPresent";
     }
 
     protected function passes(): bool

--- a/src/Rules/Accessibility/IdsAreUnique.php
+++ b/src/Rules/Accessibility/IdsAreUnique.php
@@ -18,10 +18,14 @@ class IdsAreUnique extends BaseRule
 
     public function __construct()
     {
-        $this->name = "idsAreUnique";
         $this->value = 15;
         $this->type = RuleType::Accessibility;
         $this->ids = [];
+    }
+
+    public function name(): string
+    {
+        return "idsAreUnique";
     }
 
     protected function passes(): bool

--- a/src/Rules/Accessibility/ImagesHaveAltAttributes.php
+++ b/src/Rules/Accessibility/ImagesHaveAltAttributes.php
@@ -13,9 +13,13 @@ class ImagesHaveAltAttributes extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "imagesHaveAltAttributes";
         $this->value = 14;
         $this->type = RuleType::Accessibility;
+    }
+
+    public function name(): string
+    {
+        return "imagesHaveAltAttributes";
     }
 
     protected function passes(): bool

--- a/src/Rules/Accessibility/MetaThemeColorPresent.php
+++ b/src/Rules/Accessibility/MetaThemeColorPresent.php
@@ -13,9 +13,13 @@ class MetaThemeColorPresent extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "metaThemeColorPresent";
         $this->value = 14;
         $this->type = RuleType::Accessibility;
+    }
+
+    public function name(): string
+    {
+        return "metaThemeColorPresent";
     }
 
     protected function passes(): bool

--- a/src/Rules/Accessibility/MetaViewportPresent.php
+++ b/src/Rules/Accessibility/MetaViewportPresent.php
@@ -13,9 +13,13 @@ class MetaViewportPresent extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "metaViewportPresent";
         $this->value = 14;
         $this->type = RuleType::Accessibility;
+    }
+
+    public function name(): string
+    {
+        return "metaViewportPresent";
     }
 
     protected function passes(): bool

--- a/src/Rules/Accessibility/UseLandmarkTags.php
+++ b/src/Rules/Accessibility/UseLandmarkTags.php
@@ -10,9 +10,13 @@ class UseLandmarkTags extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "useLandmarkTags";
         $this->value = 14;
         $this->type = RuleType::Accessibility;
+    }
+
+    public function name(): string
+    {
+        return "useLandmarkTags";
     }
 
     protected function passes(): bool

--- a/src/Rules/BaseRule.php
+++ b/src/Rules/BaseRule.php
@@ -11,14 +11,12 @@ class BaseRule implements Rule
 {
     protected Response $response;
 
-    protected string $name;
     protected int $value;
     protected RuleType $type;
 
     public function __construct()
     {
         $this->response = new Response();
-        $this->name = "";
         $this->value = 0;
         $this->type = RuleType::Unknown;
     }
@@ -39,7 +37,7 @@ class BaseRule implements Rule
         $passes = $this->passes();
 
         $report->setRuleType($this->type)
-            ->setName($this->name)
+            ->setName($this->name())
             ->setPasses($passes)
             ->setScore($passes ? $this->value : 0);
 
@@ -54,6 +52,11 @@ class BaseRule implements Rule
     public function value(): int
     {
         return $this->value;
+    }
+
+    public function name(): string
+    {
+        return "";
     }
 
     protected function passes(): bool

--- a/src/Rules/Performance/FastResponseTime.php
+++ b/src/Rules/Performance/FastResponseTime.php
@@ -9,9 +9,13 @@ class FastResponseTime extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "fastResponseTime";
         $this->value = 25;
         $this->type = RuleType::Performance;
+    }
+
+    public function name(): string
+    {
+        return "fastResponseTime";
     }
 
     protected function passes(): bool

--- a/src/Rules/Performance/NoRedirects.php
+++ b/src/Rules/Performance/NoRedirects.php
@@ -9,9 +9,13 @@ class NoRedirects extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "noRedirects";
         $this->value = 25;
         $this->type = RuleType::Performance;
+    }
+
+    public function name(): string
+    {
+        return "noRedirects";
     }
 
     protected function passes(): bool

--- a/src/Rules/Performance/TextCompressionEnabled.php
+++ b/src/Rules/Performance/TextCompressionEnabled.php
@@ -9,9 +9,13 @@ class TextCompressionEnabled extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "textCompressionEnabled";
         $this->value = 25;
         $this->type = RuleType::Performance;
+    }
+
+    public function name(): string
+    {
+        return "textCompressionEnabled";
     }
 
     protected function passes(): bool

--- a/src/Rules/Performance/UsesHttp2.php
+++ b/src/Rules/Performance/UsesHttp2.php
@@ -9,9 +9,13 @@ class UsesHttp2 extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "usesHttp2";
         $this->value = 25;
         $this->type = RuleType::Performance;
+    }
+
+    public function name(): string
+    {
+        return "usesHttp2";
     }
 
     public function passes(): bool

--- a/src/Rules/Security/ServerHeaderHidden.php
+++ b/src/Rules/Security/ServerHeaderHidden.php
@@ -9,9 +9,13 @@ class ServerHeaderHidden extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "serverHeaderHidden";
         $this->value = 25;
         $this->type = RuleType::Security;
+    }
+
+    public function name(): string
+    {
+        return "serverHeaderHidden";
     }
 
     protected function passes(): bool

--- a/src/Rules/Security/StrictTransportSecurityHeaderPresent.php
+++ b/src/Rules/Security/StrictTransportSecurityHeaderPresent.php
@@ -9,9 +9,13 @@ class StrictTransportSecurityHeaderPresent extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "strictTransportSecurityHeaderPresent";
         $this->value = 25;
         $this->type = RuleType::Security;
+    }
+
+    public function name(): string
+    {
+        return "strictTransportSecurityHeaderPresent";
     }
 
     protected function passes(): bool

--- a/src/Rules/Security/XFrameOptionHeaderPresent.php
+++ b/src/Rules/Security/XFrameOptionHeaderPresent.php
@@ -9,9 +9,13 @@ class XFrameOptionHeaderPresent extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "xFrameOptionsPresent";
         $this->value = 25;
         $this->type = RuleType::Security;
+    }
+
+    public function name(): string
+    {
+        return "xFrameOptionsPresent";
     }
 
     protected function passes(): bool

--- a/src/Rules/Security/XPoweredByHidden.php
+++ b/src/Rules/Security/XPoweredByHidden.php
@@ -9,9 +9,13 @@ class XPoweredByHidden extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "xPoweredByHidden";
         $this->value = 25;
         $this->type = RuleType::Security;
+    }
+
+    public function name(): string
+    {
+        return "xPoweredByHidden";
     }
 
     protected function passes(): bool

--- a/src/Rules/Seo/LangPresent.php
+++ b/src/Rules/Seo/LangPresent.php
@@ -13,9 +13,13 @@ class LangPresent extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "langPresent";
         $this->value = 25;
         $this->type = RuleType::Seo;
+    }
+
+    public function name(): string
+    {
+        return "langPresent";
     }
 
     protected function passes(): bool

--- a/src/Rules/Seo/LinksDefineHref.php
+++ b/src/Rules/Seo/LinksDefineHref.php
@@ -13,9 +13,13 @@ class LinksDefineHref extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "linksDefineHref";
         $this->value = 25;
         $this->type = RuleType::Seo;
+    }
+
+    public function name(): string
+    {
+        return "linksDefineHref";
     }
 
     protected function passes(): bool

--- a/src/Rules/Seo/MetaDescriptionPresent.php
+++ b/src/Rules/Seo/MetaDescriptionPresent.php
@@ -13,9 +13,13 @@ class MetaDescriptionPresent extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "metaDescriptionPresent";
         $this->value = 25;
         $this->type = RuleType::Seo;
+    }
+
+    public function name(): string
+    {
+        return "metaDescriptionPresent";
     }
 
     protected function passes(): bool

--- a/src/Rules/Seo/TitlePresent.php
+++ b/src/Rules/Seo/TitlePresent.php
@@ -11,9 +11,13 @@ class TitlePresent extends BaseRule
 {
     public function __construct()
     {
-        $this->name = "titlePresent";
         $this->value = 25;
         $this->type = RuleType::Seo;
+    }
+
+    public function name(): string
+    {
+        return "titlePresent";
     }
 
     protected function passes(): bool


### PR DESCRIPTION
## Added

- New methods `Lightship::allRulesPassed()`, `Lightship::rulePassed()` and `Lightship::someRulesPassed()` to assert rules pass for URLs

## Fixed

N/A

## Breaked

N/A