### PR TITLE
10-use-composer-outdated-instead-of-symfony-checker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Install
         run: docker-compose run --rm composer install
 
-      - name: Install security checker
-        run: docker-compose run --rm composer run install-security-checker
-
       - name: Analyse
         run: docker-compose run --rm composer run analyse
 
@@ -60,9 +57,6 @@ jobs:
 
       - name: Install
         run: docker-compose run --rm composer81 install
-
-      - name: Install security checker
-        run: docker-compose run --rm composer81 run install-security-checker
 
       - name: Analyse
         run: docker-compose run --rm composer81 run analyse

--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ composer install
 composer run analyse
 composer run test
 composer run lint
-composer run install-security-checker
 composer run security-check
 composer run update-check
 ```

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     "test": "pest --coverage",
     "lint": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --diff --using-cache=no --allow-risky=yes --dry-run",
     "format": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer --using-cache=no --allow-risky=yes fix",
-    "install-security-checker": "local-php-security-checker-installer",
-    "security-check": "local-php-security-checker",
+    "security-check": "composer audit --locked --no-dev",
     "update-check": "composer outdated --strict --direct"
   },
   "config": {


### PR DESCRIPTION
## Added

- Use  `composer audit` instead of symfony security check

## Fixed

N/A

## Breaking

N/A