### PR TITLE
16-fix-php-stan-xdebug-warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "fakerphp/faker": "1.21.0"
   },
   "scripts": {
-    "analyse": "phpstan analyse",
+    "analyse": "phpstan analyse --xdebug",
     "test": "pest --coverage",
     "lint": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --diff --using-cache=no --allow-risky=yes --dry-run",
     "format": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer --using-cache=no --allow-risky=yes fix",


### PR DESCRIPTION
## Added

N/A

## Fixed

- PHPStan's missing Xdebug flag warning

## Breaking

N/A